### PR TITLE
Discover tests with GoogleTest plugin.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.11.4)
 
 project("algorithms_learing")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11.4)
+cmake_minimum_required(VERSION 3.9.0)
 
 project("algorithms_learing")
 

--- a/ring_buffer/test/CMakeLists.txt
+++ b/ring_buffer/test/CMakeLists.txt
@@ -7,4 +7,4 @@ target_link_libraries (ring_buffer_test
     ring_buffer_lib
 )
 
-gtest_discover_tests(ring_buffer_test)
+gtest_add_tests(ring_buffer_test "" AUTO)

--- a/ring_buffer/test/CMakeLists.txt
+++ b/ring_buffer/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+include(GoogleTest)
 project(ring_buffer_test)
 
 add_executable (ring_buffer_test RingBufferTest.cpp)
@@ -5,4 +6,5 @@ target_link_libraries (ring_buffer_test
     gtest_main
     ring_buffer_lib
 )
-add_test(ring_buffer_test ring_buffer_test)
+
+gtest_discover_tests(ring_buffer_test)


### PR DESCRIPTION
This will show all tests inside executable with their status, instead of one test per executable.